### PR TITLE
Fix Request error handling

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -26,9 +26,8 @@ func Request(prompt string) (string, error) {
 	model.SetTemperature(float32(temperature))
 
 	response, err := model.GenerateContent(ctx, genai.Text(prompt))
-
 	if err != nil {
-		fmt.Println("error generating content", err)
+		return "", fmt.Errorf("error generating content: %w", err)
 	}
 	return parseResponse(response)
 }


### PR DESCRIPTION
## Summary
- handle `GenerateContent` errors in `gemini.Request`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840f844a5b0832b923e91de719e5d20