### PR TITLE
Fix parseResponse nil checks

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -34,15 +34,17 @@ func Request(prompt string) (string, error) {
 }
 
 func parseResponse(response *genai.GenerateContentResponse) (string, error) {
-	if response.Candidates[0].FinishReason != genai.FinishReasonStop {
-		return "", fmt.Errorf("invalid response: %s", response.Candidates[0].FinishReason)
-	}
 	if response == nil ||
 		response.Candidates == nil ||
 		len(response.Candidates) == 0 ||
 		len(response.Candidates[0].Content.Parts) == 0 {
 		return "", fmt.Errorf("invalid response")
 	}
+
+	if response.Candidates[0].FinishReason != genai.FinishReasonStop {
+		return "", fmt.Errorf("invalid response: %s", response.Candidates[0].FinishReason)
+	}
+
 	return fmt.Sprintf("%s", response.Candidates[0].Content.Parts[0]), nil
 }
 

--- a/gemini/gemini_test.go
+++ b/gemini/gemini_test.go
@@ -1,0 +1,49 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/google/generative-ai-go/genai"
+)
+
+func TestParseResponseNil(t *testing.T) {
+	_, err := parseResponse(nil)
+	if err == nil {
+		t.Fatal("expected error for nil response")
+	}
+
+	resp := &genai.GenerateContentResponse{}
+	_, err = parseResponse(resp)
+	if err == nil {
+		t.Fatal("expected error for nil candidates")
+	}
+
+	resp.Candidates = []*genai.Candidate{}
+	_, err = parseResponse(resp)
+	if err == nil {
+		t.Fatal("expected error for empty candidates")
+	}
+
+	resp.Candidates = []*genai.Candidate{{Content: &genai.Content{}}}
+	_, err = parseResponse(resp)
+	if err == nil {
+		t.Fatal("expected error for empty parts")
+	}
+}
+
+func TestParseResponseSuccess(t *testing.T) {
+	part := genai.Text("ok")
+	resp := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			FinishReason: genai.FinishReasonStop,
+			Content:      &genai.Content{Parts: []genai.Part{part}},
+		}},
+	}
+	s, err := parseResponse(resp)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if s != "ok" {
+		t.Fatalf("expected 'ok', got %s", s)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid index access before nil validations
- test parseResponse nil cases

## Testing
- `go test ./...`